### PR TITLE
Languages lists

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,3 +51,7 @@ To update the KPI UI's translatable sources using Poedit, follow these instructi
 
 * From the `locale` directory inside the KPI root, run `tx pull --all`;
 * Commit and push the updates to this repository, `form-builder-translations`, whose root should be the `locale` directory.
+
+# Languages lists
+
+The `<lang>/languages.json` files, besides containing localized names of languages, is the source data for building languages selectors in KPI. When creating new languages, please make sure to duplicate `en/languages.json` to new directory and treat existing english names as fallback/default values.

--- a/ar/languages.json
+++ b/ar/languages.json
@@ -1,0 +1,78 @@
+[
+  {
+    "code": "todo_ar",
+    "localized_name": "Arabic"
+  },
+  {
+    "code": "todo_cs",
+    "localized_name": "Czech"
+  },
+  {
+    "code": "todo_de",
+    "localized_name": "German"
+  },
+  {
+    "code": "todo_de_DE",
+    "localized_name": "German"
+  },
+  {
+    "code": "todo_en",
+    "localized_name": "English"
+  },
+  {
+    "code": "todo_es",
+    "localized_name": "Spanish"
+  },
+  {
+    "code": "todo_fr",
+    "localized_name": "French"
+  },
+  {
+    "code": "todo_hi",
+    "localized_name": "Hindi"
+  },
+  {
+    "code": "todo_hu",
+    "localized_name": "Hungarian"
+  },
+  {
+    "code": "todo_it",
+    "localized_name": "Italian"
+  },
+  {
+    "code": "todo_km",
+    "localized_name": "Khmer"
+  },
+  {
+    "code": "todo_ku",
+    "localized_name": "Kurdish"
+  },
+  {
+    "code": "todo_nl",
+    "localized_name": "Dutch"
+  },
+  {
+    "code": "todo_pl",
+    "localized_name": "Polish"
+  },
+  {
+    "code": "todo_pt",
+    "localized_name": "Portugese"
+  },
+  {
+    "code": "todo_ru",
+    "localized_name": "Russian"
+  },
+  {
+    "code": "todo_sw",
+    "localized_name": "Swahili"
+  },
+  {
+    "code": "todo_tr",
+    "localized_name": "Turkish"
+  },
+  {
+    "code": "todo_zh",
+    "localized_name": "Chinese"
+  }
+]

--- a/cs/languages.json
+++ b/cs/languages.json
@@ -1,0 +1,78 @@
+[
+  {
+    "code": "todo_ar",
+    "localized_name": "Arabic"
+  },
+  {
+    "code": "todo_cs",
+    "localized_name": "Czech"
+  },
+  {
+    "code": "todo_de",
+    "localized_name": "German"
+  },
+  {
+    "code": "todo_de_DE",
+    "localized_name": "German"
+  },
+  {
+    "code": "todo_en",
+    "localized_name": "English"
+  },
+  {
+    "code": "todo_es",
+    "localized_name": "Spanish"
+  },
+  {
+    "code": "todo_fr",
+    "localized_name": "French"
+  },
+  {
+    "code": "todo_hi",
+    "localized_name": "Hindi"
+  },
+  {
+    "code": "todo_hu",
+    "localized_name": "Hungarian"
+  },
+  {
+    "code": "todo_it",
+    "localized_name": "Italian"
+  },
+  {
+    "code": "todo_km",
+    "localized_name": "Khmer"
+  },
+  {
+    "code": "todo_ku",
+    "localized_name": "Kurdish"
+  },
+  {
+    "code": "todo_nl",
+    "localized_name": "Dutch"
+  },
+  {
+    "code": "todo_pl",
+    "localized_name": "Polish"
+  },
+  {
+    "code": "todo_pt",
+    "localized_name": "Portugese"
+  },
+  {
+    "code": "todo_ru",
+    "localized_name": "Russian"
+  },
+  {
+    "code": "todo_sw",
+    "localized_name": "Swahili"
+  },
+  {
+    "code": "todo_tr",
+    "localized_name": "Turkish"
+  },
+  {
+    "code": "todo_zh",
+    "localized_name": "Chinese"
+  }
+]

--- a/de/languages.json
+++ b/de/languages.json
@@ -1,0 +1,78 @@
+[
+  {
+    "code": "todo_ar",
+    "localized_name": "Arabic"
+  },
+  {
+    "code": "todo_cs",
+    "localized_name": "Czech"
+  },
+  {
+    "code": "todo_de",
+    "localized_name": "German"
+  },
+  {
+    "code": "todo_de_DE",
+    "localized_name": "German"
+  },
+  {
+    "code": "todo_en",
+    "localized_name": "English"
+  },
+  {
+    "code": "todo_es",
+    "localized_name": "Spanish"
+  },
+  {
+    "code": "todo_fr",
+    "localized_name": "French"
+  },
+  {
+    "code": "todo_hi",
+    "localized_name": "Hindi"
+  },
+  {
+    "code": "todo_hu",
+    "localized_name": "Hungarian"
+  },
+  {
+    "code": "todo_it",
+    "localized_name": "Italian"
+  },
+  {
+    "code": "todo_km",
+    "localized_name": "Khmer"
+  },
+  {
+    "code": "todo_ku",
+    "localized_name": "Kurdish"
+  },
+  {
+    "code": "todo_nl",
+    "localized_name": "Dutch"
+  },
+  {
+    "code": "todo_pl",
+    "localized_name": "Polish"
+  },
+  {
+    "code": "todo_pt",
+    "localized_name": "Portugese"
+  },
+  {
+    "code": "todo_ru",
+    "localized_name": "Russian"
+  },
+  {
+    "code": "todo_sw",
+    "localized_name": "Swahili"
+  },
+  {
+    "code": "todo_tr",
+    "localized_name": "Turkish"
+  },
+  {
+    "code": "todo_zh",
+    "localized_name": "Chinese"
+  }
+]

--- a/de_DE/languages.json
+++ b/de_DE/languages.json
@@ -1,0 +1,78 @@
+[
+  {
+    "code": "todo_ar",
+    "localized_name": "Arabic"
+  },
+  {
+    "code": "todo_cs",
+    "localized_name": "Czech"
+  },
+  {
+    "code": "todo_de",
+    "localized_name": "German"
+  },
+  {
+    "code": "todo_de_DE",
+    "localized_name": "German"
+  },
+  {
+    "code": "todo_en",
+    "localized_name": "English"
+  },
+  {
+    "code": "todo_es",
+    "localized_name": "Spanish"
+  },
+  {
+    "code": "todo_fr",
+    "localized_name": "French"
+  },
+  {
+    "code": "todo_hi",
+    "localized_name": "Hindi"
+  },
+  {
+    "code": "todo_hu",
+    "localized_name": "Hungarian"
+  },
+  {
+    "code": "todo_it",
+    "localized_name": "Italian"
+  },
+  {
+    "code": "todo_km",
+    "localized_name": "Khmer"
+  },
+  {
+    "code": "todo_ku",
+    "localized_name": "Kurdish"
+  },
+  {
+    "code": "todo_nl",
+    "localized_name": "Dutch"
+  },
+  {
+    "code": "todo_pl",
+    "localized_name": "Polish"
+  },
+  {
+    "code": "todo_pt",
+    "localized_name": "Portugese"
+  },
+  {
+    "code": "todo_ru",
+    "localized_name": "Russian"
+  },
+  {
+    "code": "todo_sw",
+    "localized_name": "Swahili"
+  },
+  {
+    "code": "todo_tr",
+    "localized_name": "Turkish"
+  },
+  {
+    "code": "todo_zh",
+    "localized_name": "Chinese"
+  }
+]

--- a/en/languages.json
+++ b/en/languages.json
@@ -1,0 +1,78 @@
+[
+  {
+    "code": "todo_ar",
+    "localized_name": "Arabic"
+  },
+  {
+    "code": "todo_cs",
+    "localized_name": "Czech"
+  },
+  {
+    "code": "todo_de",
+    "localized_name": "German"
+  },
+  {
+    "code": "todo_de_DE",
+    "localized_name": "German"
+  },
+  {
+    "code": "todo_en",
+    "localized_name": "English"
+  },
+  {
+    "code": "todo_es",
+    "localized_name": "Spanish"
+  },
+  {
+    "code": "todo_fr",
+    "localized_name": "French"
+  },
+  {
+    "code": "todo_hi",
+    "localized_name": "Hindi"
+  },
+  {
+    "code": "todo_hu",
+    "localized_name": "Hungarian"
+  },
+  {
+    "code": "todo_it",
+    "localized_name": "Italian"
+  },
+  {
+    "code": "todo_km",
+    "localized_name": "Khmer"
+  },
+  {
+    "code": "todo_ku",
+    "localized_name": "Kurdish"
+  },
+  {
+    "code": "todo_nl",
+    "localized_name": "Dutch"
+  },
+  {
+    "code": "todo_pl",
+    "localized_name": "Polish"
+  },
+  {
+    "code": "todo_pt",
+    "localized_name": "Portugese"
+  },
+  {
+    "code": "todo_ru",
+    "localized_name": "Russian"
+  },
+  {
+    "code": "todo_sw",
+    "localized_name": "Swahili"
+  },
+  {
+    "code": "todo_tr",
+    "localized_name": "Turkish"
+  },
+  {
+    "code": "todo_zh",
+    "localized_name": "Chinese"
+  }
+]

--- a/es/languages.json
+++ b/es/languages.json
@@ -1,0 +1,78 @@
+[
+  {
+    "code": "todo_ar",
+    "localized_name": "Arabic"
+  },
+  {
+    "code": "todo_cs",
+    "localized_name": "Czech"
+  },
+  {
+    "code": "todo_de",
+    "localized_name": "German"
+  },
+  {
+    "code": "todo_de_DE",
+    "localized_name": "German"
+  },
+  {
+    "code": "todo_en",
+    "localized_name": "English"
+  },
+  {
+    "code": "todo_es",
+    "localized_name": "Spanish"
+  },
+  {
+    "code": "todo_fr",
+    "localized_name": "French"
+  },
+  {
+    "code": "todo_hi",
+    "localized_name": "Hindi"
+  },
+  {
+    "code": "todo_hu",
+    "localized_name": "Hungarian"
+  },
+  {
+    "code": "todo_it",
+    "localized_name": "Italian"
+  },
+  {
+    "code": "todo_km",
+    "localized_name": "Khmer"
+  },
+  {
+    "code": "todo_ku",
+    "localized_name": "Kurdish"
+  },
+  {
+    "code": "todo_nl",
+    "localized_name": "Dutch"
+  },
+  {
+    "code": "todo_pl",
+    "localized_name": "Polish"
+  },
+  {
+    "code": "todo_pt",
+    "localized_name": "Portugese"
+  },
+  {
+    "code": "todo_ru",
+    "localized_name": "Russian"
+  },
+  {
+    "code": "todo_sw",
+    "localized_name": "Swahili"
+  },
+  {
+    "code": "todo_tr",
+    "localized_name": "Turkish"
+  },
+  {
+    "code": "todo_zh",
+    "localized_name": "Chinese"
+  }
+]

--- a/fr/languages.json
+++ b/fr/languages.json
@@ -1,0 +1,78 @@
+[
+  {
+    "code": "todo_ar",
+    "localized_name": "Arabic"
+  },
+  {
+    "code": "todo_cs",
+    "localized_name": "Czech"
+  },
+  {
+    "code": "todo_de",
+    "localized_name": "German"
+  },
+  {
+    "code": "todo_de_DE",
+    "localized_name": "German"
+  },
+  {
+    "code": "todo_en",
+    "localized_name": "English"
+  },
+  {
+    "code": "todo_es",
+    "localized_name": "Spanish"
+  },
+  {
+    "code": "todo_fr",
+    "localized_name": "French"
+  },
+  {
+    "code": "todo_hi",
+    "localized_name": "Hindi"
+  },
+  {
+    "code": "todo_hu",
+    "localized_name": "Hungarian"
+  },
+  {
+    "code": "todo_it",
+    "localized_name": "Italian"
+  },
+  {
+    "code": "todo_km",
+    "localized_name": "Khmer"
+  },
+  {
+    "code": "todo_ku",
+    "localized_name": "Kurdish"
+  },
+  {
+    "code": "todo_nl",
+    "localized_name": "Dutch"
+  },
+  {
+    "code": "todo_pl",
+    "localized_name": "Polish"
+  },
+  {
+    "code": "todo_pt",
+    "localized_name": "Portugese"
+  },
+  {
+    "code": "todo_ru",
+    "localized_name": "Russian"
+  },
+  {
+    "code": "todo_sw",
+    "localized_name": "Swahili"
+  },
+  {
+    "code": "todo_tr",
+    "localized_name": "Turkish"
+  },
+  {
+    "code": "todo_zh",
+    "localized_name": "Chinese"
+  }
+]

--- a/hi/languages.json
+++ b/hi/languages.json
@@ -1,0 +1,78 @@
+[
+  {
+    "code": "todo_ar",
+    "localized_name": "Arabic"
+  },
+  {
+    "code": "todo_cs",
+    "localized_name": "Czech"
+  },
+  {
+    "code": "todo_de",
+    "localized_name": "German"
+  },
+  {
+    "code": "todo_de_DE",
+    "localized_name": "German"
+  },
+  {
+    "code": "todo_en",
+    "localized_name": "English"
+  },
+  {
+    "code": "todo_es",
+    "localized_name": "Spanish"
+  },
+  {
+    "code": "todo_fr",
+    "localized_name": "French"
+  },
+  {
+    "code": "todo_hi",
+    "localized_name": "Hindi"
+  },
+  {
+    "code": "todo_hu",
+    "localized_name": "Hungarian"
+  },
+  {
+    "code": "todo_it",
+    "localized_name": "Italian"
+  },
+  {
+    "code": "todo_km",
+    "localized_name": "Khmer"
+  },
+  {
+    "code": "todo_ku",
+    "localized_name": "Kurdish"
+  },
+  {
+    "code": "todo_nl",
+    "localized_name": "Dutch"
+  },
+  {
+    "code": "todo_pl",
+    "localized_name": "Polish"
+  },
+  {
+    "code": "todo_pt",
+    "localized_name": "Portugese"
+  },
+  {
+    "code": "todo_ru",
+    "localized_name": "Russian"
+  },
+  {
+    "code": "todo_sw",
+    "localized_name": "Swahili"
+  },
+  {
+    "code": "todo_tr",
+    "localized_name": "Turkish"
+  },
+  {
+    "code": "todo_zh",
+    "localized_name": "Chinese"
+  }
+]

--- a/hu/languages.json
+++ b/hu/languages.json
@@ -1,0 +1,78 @@
+[
+  {
+    "code": "todo_ar",
+    "localized_name": "Arabic"
+  },
+  {
+    "code": "todo_cs",
+    "localized_name": "Czech"
+  },
+  {
+    "code": "todo_de",
+    "localized_name": "German"
+  },
+  {
+    "code": "todo_de_DE",
+    "localized_name": "German"
+  },
+  {
+    "code": "todo_en",
+    "localized_name": "English"
+  },
+  {
+    "code": "todo_es",
+    "localized_name": "Spanish"
+  },
+  {
+    "code": "todo_fr",
+    "localized_name": "French"
+  },
+  {
+    "code": "todo_hi",
+    "localized_name": "Hindi"
+  },
+  {
+    "code": "todo_hu",
+    "localized_name": "Hungarian"
+  },
+  {
+    "code": "todo_it",
+    "localized_name": "Italian"
+  },
+  {
+    "code": "todo_km",
+    "localized_name": "Khmer"
+  },
+  {
+    "code": "todo_ku",
+    "localized_name": "Kurdish"
+  },
+  {
+    "code": "todo_nl",
+    "localized_name": "Dutch"
+  },
+  {
+    "code": "todo_pl",
+    "localized_name": "Polish"
+  },
+  {
+    "code": "todo_pt",
+    "localized_name": "Portugese"
+  },
+  {
+    "code": "todo_ru",
+    "localized_name": "Russian"
+  },
+  {
+    "code": "todo_sw",
+    "localized_name": "Swahili"
+  },
+  {
+    "code": "todo_tr",
+    "localized_name": "Turkish"
+  },
+  {
+    "code": "todo_zh",
+    "localized_name": "Chinese"
+  }
+]

--- a/it/languages.json
+++ b/it/languages.json
@@ -1,0 +1,78 @@
+[
+  {
+    "code": "todo_ar",
+    "localized_name": "Arabic"
+  },
+  {
+    "code": "todo_cs",
+    "localized_name": "Czech"
+  },
+  {
+    "code": "todo_de",
+    "localized_name": "German"
+  },
+  {
+    "code": "todo_de_DE",
+    "localized_name": "German"
+  },
+  {
+    "code": "todo_en",
+    "localized_name": "English"
+  },
+  {
+    "code": "todo_es",
+    "localized_name": "Spanish"
+  },
+  {
+    "code": "todo_fr",
+    "localized_name": "French"
+  },
+  {
+    "code": "todo_hi",
+    "localized_name": "Hindi"
+  },
+  {
+    "code": "todo_hu",
+    "localized_name": "Hungarian"
+  },
+  {
+    "code": "todo_it",
+    "localized_name": "Italian"
+  },
+  {
+    "code": "todo_km",
+    "localized_name": "Khmer"
+  },
+  {
+    "code": "todo_ku",
+    "localized_name": "Kurdish"
+  },
+  {
+    "code": "todo_nl",
+    "localized_name": "Dutch"
+  },
+  {
+    "code": "todo_pl",
+    "localized_name": "Polish"
+  },
+  {
+    "code": "todo_pt",
+    "localized_name": "Portugese"
+  },
+  {
+    "code": "todo_ru",
+    "localized_name": "Russian"
+  },
+  {
+    "code": "todo_sw",
+    "localized_name": "Swahili"
+  },
+  {
+    "code": "todo_tr",
+    "localized_name": "Turkish"
+  },
+  {
+    "code": "todo_zh",
+    "localized_name": "Chinese"
+  }
+]

--- a/km/languages.json
+++ b/km/languages.json
@@ -1,0 +1,78 @@
+[
+  {
+    "code": "todo_ar",
+    "localized_name": "Arabic"
+  },
+  {
+    "code": "todo_cs",
+    "localized_name": "Czech"
+  },
+  {
+    "code": "todo_de",
+    "localized_name": "German"
+  },
+  {
+    "code": "todo_de_DE",
+    "localized_name": "German"
+  },
+  {
+    "code": "todo_en",
+    "localized_name": "English"
+  },
+  {
+    "code": "todo_es",
+    "localized_name": "Spanish"
+  },
+  {
+    "code": "todo_fr",
+    "localized_name": "French"
+  },
+  {
+    "code": "todo_hi",
+    "localized_name": "Hindi"
+  },
+  {
+    "code": "todo_hu",
+    "localized_name": "Hungarian"
+  },
+  {
+    "code": "todo_it",
+    "localized_name": "Italian"
+  },
+  {
+    "code": "todo_km",
+    "localized_name": "Khmer"
+  },
+  {
+    "code": "todo_ku",
+    "localized_name": "Kurdish"
+  },
+  {
+    "code": "todo_nl",
+    "localized_name": "Dutch"
+  },
+  {
+    "code": "todo_pl",
+    "localized_name": "Polish"
+  },
+  {
+    "code": "todo_pt",
+    "localized_name": "Portugese"
+  },
+  {
+    "code": "todo_ru",
+    "localized_name": "Russian"
+  },
+  {
+    "code": "todo_sw",
+    "localized_name": "Swahili"
+  },
+  {
+    "code": "todo_tr",
+    "localized_name": "Turkish"
+  },
+  {
+    "code": "todo_zh",
+    "localized_name": "Chinese"
+  }
+]

--- a/ku/languages.json
+++ b/ku/languages.json
@@ -1,0 +1,78 @@
+[
+  {
+    "code": "todo_ar",
+    "localized_name": "Arabic"
+  },
+  {
+    "code": "todo_cs",
+    "localized_name": "Czech"
+  },
+  {
+    "code": "todo_de",
+    "localized_name": "German"
+  },
+  {
+    "code": "todo_de_DE",
+    "localized_name": "German"
+  },
+  {
+    "code": "todo_en",
+    "localized_name": "English"
+  },
+  {
+    "code": "todo_es",
+    "localized_name": "Spanish"
+  },
+  {
+    "code": "todo_fr",
+    "localized_name": "French"
+  },
+  {
+    "code": "todo_hi",
+    "localized_name": "Hindi"
+  },
+  {
+    "code": "todo_hu",
+    "localized_name": "Hungarian"
+  },
+  {
+    "code": "todo_it",
+    "localized_name": "Italian"
+  },
+  {
+    "code": "todo_km",
+    "localized_name": "Khmer"
+  },
+  {
+    "code": "todo_ku",
+    "localized_name": "Kurdish"
+  },
+  {
+    "code": "todo_nl",
+    "localized_name": "Dutch"
+  },
+  {
+    "code": "todo_pl",
+    "localized_name": "Polish"
+  },
+  {
+    "code": "todo_pt",
+    "localized_name": "Portugese"
+  },
+  {
+    "code": "todo_ru",
+    "localized_name": "Russian"
+  },
+  {
+    "code": "todo_sw",
+    "localized_name": "Swahili"
+  },
+  {
+    "code": "todo_tr",
+    "localized_name": "Turkish"
+  },
+  {
+    "code": "todo_zh",
+    "localized_name": "Chinese"
+  }
+]

--- a/nl/languages.json
+++ b/nl/languages.json
@@ -1,0 +1,78 @@
+[
+  {
+    "code": "todo_ar",
+    "localized_name": "Arabic"
+  },
+  {
+    "code": "todo_cs",
+    "localized_name": "Czech"
+  },
+  {
+    "code": "todo_de",
+    "localized_name": "German"
+  },
+  {
+    "code": "todo_de_DE",
+    "localized_name": "German"
+  },
+  {
+    "code": "todo_en",
+    "localized_name": "English"
+  },
+  {
+    "code": "todo_es",
+    "localized_name": "Spanish"
+  },
+  {
+    "code": "todo_fr",
+    "localized_name": "French"
+  },
+  {
+    "code": "todo_hi",
+    "localized_name": "Hindi"
+  },
+  {
+    "code": "todo_hu",
+    "localized_name": "Hungarian"
+  },
+  {
+    "code": "todo_it",
+    "localized_name": "Italian"
+  },
+  {
+    "code": "todo_km",
+    "localized_name": "Khmer"
+  },
+  {
+    "code": "todo_ku",
+    "localized_name": "Kurdish"
+  },
+  {
+    "code": "todo_nl",
+    "localized_name": "Dutch"
+  },
+  {
+    "code": "todo_pl",
+    "localized_name": "Polish"
+  },
+  {
+    "code": "todo_pt",
+    "localized_name": "Portugese"
+  },
+  {
+    "code": "todo_ru",
+    "localized_name": "Russian"
+  },
+  {
+    "code": "todo_sw",
+    "localized_name": "Swahili"
+  },
+  {
+    "code": "todo_tr",
+    "localized_name": "Turkish"
+  },
+  {
+    "code": "todo_zh",
+    "localized_name": "Chinese"
+  }
+]

--- a/pl/languages.json
+++ b/pl/languages.json
@@ -1,0 +1,78 @@
+[
+  {
+    "code": "todo_ar",
+    "localized_name": "arabski"
+  },
+  {
+    "code": "todo_cs",
+    "localized_name": "czeski"
+  },
+  {
+    "code": "todo_de",
+    "localized_name": "niemiecki"
+  },
+  {
+    "code": "todo_de_DE",
+    "localized_name": "niemiecki"
+  },
+  {
+    "code": "todo_en",
+    "localized_name": "angielski"
+  },
+  {
+    "code": "todo_es",
+    "localized_name": "hiszpański"
+  },
+  {
+    "code": "todo_fr",
+    "localized_name": "francuski"
+  },
+  {
+    "code": "todo_hi",
+    "localized_name": "hindi"
+  },
+  {
+    "code": "todo_hu",
+    "localized_name": "węgierski"
+  },
+  {
+    "code": "todo_it",
+    "localized_name": "włoski"
+  },
+  {
+    "code": "todo_km",
+    "localized_name": "khmerski"
+  },
+  {
+    "code": "todo_ku",
+    "localized_name": "kurdyjski"
+  },
+  {
+    "code": "todo_nl",
+    "localized_name": "duński"
+  },
+  {
+    "code": "todo_pl",
+    "localized_name": "polski"
+  },
+  {
+    "code": "todo_pt",
+    "localized_name": "portugalski"
+  },
+  {
+    "code": "todo_ru",
+    "localized_name": "rosyjski"
+  },
+  {
+    "code": "todo_sw",
+    "localized_name": "suahili"
+  },
+  {
+    "code": "todo_tr",
+    "localized_name": "turecki"
+  },
+  {
+    "code": "todo_zh",
+    "localized_name": "chiński"
+  }
+]

--- a/pt/languages.json
+++ b/pt/languages.json
@@ -1,0 +1,78 @@
+[
+  {
+    "code": "todo_ar",
+    "localized_name": "Arabic"
+  },
+  {
+    "code": "todo_cs",
+    "localized_name": "Czech"
+  },
+  {
+    "code": "todo_de",
+    "localized_name": "German"
+  },
+  {
+    "code": "todo_de_DE",
+    "localized_name": "German"
+  },
+  {
+    "code": "todo_en",
+    "localized_name": "English"
+  },
+  {
+    "code": "todo_es",
+    "localized_name": "Spanish"
+  },
+  {
+    "code": "todo_fr",
+    "localized_name": "French"
+  },
+  {
+    "code": "todo_hi",
+    "localized_name": "Hindi"
+  },
+  {
+    "code": "todo_hu",
+    "localized_name": "Hungarian"
+  },
+  {
+    "code": "todo_it",
+    "localized_name": "Italian"
+  },
+  {
+    "code": "todo_km",
+    "localized_name": "Khmer"
+  },
+  {
+    "code": "todo_ku",
+    "localized_name": "Kurdish"
+  },
+  {
+    "code": "todo_nl",
+    "localized_name": "Dutch"
+  },
+  {
+    "code": "todo_pl",
+    "localized_name": "Polish"
+  },
+  {
+    "code": "todo_pt",
+    "localized_name": "Portugese"
+  },
+  {
+    "code": "todo_ru",
+    "localized_name": "Russian"
+  },
+  {
+    "code": "todo_sw",
+    "localized_name": "Swahili"
+  },
+  {
+    "code": "todo_tr",
+    "localized_name": "Turkish"
+  },
+  {
+    "code": "todo_zh",
+    "localized_name": "Chinese"
+  }
+]

--- a/ru/languages.json
+++ b/ru/languages.json
@@ -1,0 +1,78 @@
+[
+  {
+    "code": "todo_ar",
+    "localized_name": "Arabic"
+  },
+  {
+    "code": "todo_cs",
+    "localized_name": "Czech"
+  },
+  {
+    "code": "todo_de",
+    "localized_name": "German"
+  },
+  {
+    "code": "todo_de_DE",
+    "localized_name": "German"
+  },
+  {
+    "code": "todo_en",
+    "localized_name": "English"
+  },
+  {
+    "code": "todo_es",
+    "localized_name": "Spanish"
+  },
+  {
+    "code": "todo_fr",
+    "localized_name": "French"
+  },
+  {
+    "code": "todo_hi",
+    "localized_name": "Hindi"
+  },
+  {
+    "code": "todo_hu",
+    "localized_name": "Hungarian"
+  },
+  {
+    "code": "todo_it",
+    "localized_name": "Italian"
+  },
+  {
+    "code": "todo_km",
+    "localized_name": "Khmer"
+  },
+  {
+    "code": "todo_ku",
+    "localized_name": "Kurdish"
+  },
+  {
+    "code": "todo_nl",
+    "localized_name": "Dutch"
+  },
+  {
+    "code": "todo_pl",
+    "localized_name": "Polish"
+  },
+  {
+    "code": "todo_pt",
+    "localized_name": "Portugese"
+  },
+  {
+    "code": "todo_ru",
+    "localized_name": "Russian"
+  },
+  {
+    "code": "todo_sw",
+    "localized_name": "Swahili"
+  },
+  {
+    "code": "todo_tr",
+    "localized_name": "Turkish"
+  },
+  {
+    "code": "todo_zh",
+    "localized_name": "Chinese"
+  }
+]

--- a/sw/languages.json
+++ b/sw/languages.json
@@ -1,0 +1,78 @@
+[
+  {
+    "code": "todo_ar",
+    "localized_name": "Arabic"
+  },
+  {
+    "code": "todo_cs",
+    "localized_name": "Czech"
+  },
+  {
+    "code": "todo_de",
+    "localized_name": "German"
+  },
+  {
+    "code": "todo_de_DE",
+    "localized_name": "German"
+  },
+  {
+    "code": "todo_en",
+    "localized_name": "English"
+  },
+  {
+    "code": "todo_es",
+    "localized_name": "Spanish"
+  },
+  {
+    "code": "todo_fr",
+    "localized_name": "French"
+  },
+  {
+    "code": "todo_hi",
+    "localized_name": "Hindi"
+  },
+  {
+    "code": "todo_hu",
+    "localized_name": "Hungarian"
+  },
+  {
+    "code": "todo_it",
+    "localized_name": "Italian"
+  },
+  {
+    "code": "todo_km",
+    "localized_name": "Khmer"
+  },
+  {
+    "code": "todo_ku",
+    "localized_name": "Kurdish"
+  },
+  {
+    "code": "todo_nl",
+    "localized_name": "Dutch"
+  },
+  {
+    "code": "todo_pl",
+    "localized_name": "Polish"
+  },
+  {
+    "code": "todo_pt",
+    "localized_name": "Portugese"
+  },
+  {
+    "code": "todo_ru",
+    "localized_name": "Russian"
+  },
+  {
+    "code": "todo_sw",
+    "localized_name": "Swahili"
+  },
+  {
+    "code": "todo_tr",
+    "localized_name": "Turkish"
+  },
+  {
+    "code": "todo_zh",
+    "localized_name": "Chinese"
+  }
+]

--- a/tr/languages.json
+++ b/tr/languages.json
@@ -1,0 +1,78 @@
+[
+  {
+    "code": "todo_ar",
+    "localized_name": "Arabic"
+  },
+  {
+    "code": "todo_cs",
+    "localized_name": "Czech"
+  },
+  {
+    "code": "todo_de",
+    "localized_name": "German"
+  },
+  {
+    "code": "todo_de_DE",
+    "localized_name": "German"
+  },
+  {
+    "code": "todo_en",
+    "localized_name": "English"
+  },
+  {
+    "code": "todo_es",
+    "localized_name": "Spanish"
+  },
+  {
+    "code": "todo_fr",
+    "localized_name": "French"
+  },
+  {
+    "code": "todo_hi",
+    "localized_name": "Hindi"
+  },
+  {
+    "code": "todo_hu",
+    "localized_name": "Hungarian"
+  },
+  {
+    "code": "todo_it",
+    "localized_name": "Italian"
+  },
+  {
+    "code": "todo_km",
+    "localized_name": "Khmer"
+  },
+  {
+    "code": "todo_ku",
+    "localized_name": "Kurdish"
+  },
+  {
+    "code": "todo_nl",
+    "localized_name": "Dutch"
+  },
+  {
+    "code": "todo_pl",
+    "localized_name": "Polish"
+  },
+  {
+    "code": "todo_pt",
+    "localized_name": "Portugese"
+  },
+  {
+    "code": "todo_ru",
+    "localized_name": "Russian"
+  },
+  {
+    "code": "todo_sw",
+    "localized_name": "Swahili"
+  },
+  {
+    "code": "todo_tr",
+    "localized_name": "Turkish"
+  },
+  {
+    "code": "todo_zh",
+    "localized_name": "Chinese"
+  }
+]

--- a/zh/languages.json
+++ b/zh/languages.json
@@ -1,0 +1,78 @@
+[
+  {
+    "code": "todo_ar",
+    "localized_name": "Arabic"
+  },
+  {
+    "code": "todo_cs",
+    "localized_name": "Czech"
+  },
+  {
+    "code": "todo_de",
+    "localized_name": "German"
+  },
+  {
+    "code": "todo_de_DE",
+    "localized_name": "German"
+  },
+  {
+    "code": "todo_en",
+    "localized_name": "English"
+  },
+  {
+    "code": "todo_es",
+    "localized_name": "Spanish"
+  },
+  {
+    "code": "todo_fr",
+    "localized_name": "French"
+  },
+  {
+    "code": "todo_hi",
+    "localized_name": "Hindi"
+  },
+  {
+    "code": "todo_hu",
+    "localized_name": "Hungarian"
+  },
+  {
+    "code": "todo_it",
+    "localized_name": "Italian"
+  },
+  {
+    "code": "todo_km",
+    "localized_name": "Khmer"
+  },
+  {
+    "code": "todo_ku",
+    "localized_name": "Kurdish"
+  },
+  {
+    "code": "todo_nl",
+    "localized_name": "Dutch"
+  },
+  {
+    "code": "todo_pl",
+    "localized_name": "Polish"
+  },
+  {
+    "code": "todo_pt",
+    "localized_name": "Portugese"
+  },
+  {
+    "code": "todo_ru",
+    "localized_name": "Russian"
+  },
+  {
+    "code": "todo_sw",
+    "localized_name": "Swahili"
+  },
+  {
+    "code": "todo_tr",
+    "localized_name": "Turkish"
+  },
+  {
+    "code": "todo_zh",
+    "localized_name": "Chinese"
+  }
+]


### PR DESCRIPTION
This is a first step to allow KPI to have a SSOT for languages. We plan to use those list for the Form Translations and NLP features. This is initial PR with just some sample languages defined. We didn't choose what codes we will use, so for now all of them are just `todo_…` so it's clear we need to update them.

Part of kobotoolbox/kpi/issues/3375