### PR TITLE
Update the README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,14 +25,22 @@ You might be wondering: "I just added a new string to KPI. How do I translate it
 
 ## Step 3: Upload the new strings to Transifex
 
-* Install the Transifex client if you haven't already (`pip install transifex-client`).
-* From the `locale` directory inside the KPI root, run `tx push -s` to push all of the updates to Transifex.
+Note: It's recommended that you install and run Transifex-CLI in a virtual environment or container  
+* Install the Transifex-CLI if you haven't already:
+  * `curl -o- https://raw.githubusercontent.com/transifex/cli/master/install.sh | bash`
+  * Retrieve your API Token from the Transifex website in https://app.transifex.com/user/settings/api/
+  * Run `tx migrate` if there are issues with the config file
+* From the `locale` directory inside the KPI root, run `tx push -s` to push both new source files to Transifex.
 
 ## Step 4: Use the Transifex web interface to translate the new strings
 
 * The Transifex project is called "kobotoolbox" and is available at https://www.transifex.com/kobotoolbox/kobotoolbox/.
+  * The `django.po` resource contains strings from the backend `*.py` files
+  * The `djangojs.po` resource contains strings from the frontend javascript files
 
 ## Step 5: Retrieve the new translations from Transifex and commit to this repository
 
-* From the `locale` directory inside the KPI root, run `tx pull --all`;
+* From the `locale` directory inside the KPI root, run `tx pull -a -f --mode reviewed`;
 * Commit and push the updates to this repository, `form-builder-translations`, whose root should be the `locale` directory.
+
+Alternatively, there is a Github Action that runs on the 1st and the 15th of every month to pull updated strings.


### PR DESCRIPTION
Update the readme file to use the new Transifex-CLI instead of the `transifex-client` python library